### PR TITLE
add support for react components with no propTypes

### DIFF
--- a/react-to-webcomponent-test.js
+++ b/react-to-webcomponent-test.js
@@ -67,7 +67,7 @@ QUnit.test("works with attributes set with propTypes", function(assert) {
 	var oldError = console.error;
 	console.error = function(message) {
 		assert.ok(message.includes("required"), "got a warning with required");
-		oldError = console.error;
+		console.error = oldError;
 	}
 	fixture.appendChild(myGreeting);
 
@@ -78,6 +78,29 @@ QUnit.test("works with attributes set with propTypes", function(assert) {
 	assert.equal(fixture.firstElementChild.innerHTML, "<h1>Hello, Christopher</h1>");
 
 
+
+});
+
+QUnit.test("works with no props", function(assert) {
+	class Greeting extends React.Component {
+		render() {
+			return <h1>Hello, unnamed user</h1>;
+		}
+	}
+
+	var MyGreeting = reactToWebComponent(Greeting, React, ReactDOM)
+
+	customElements.define("my-plain-greeting", MyGreeting);
+
+	var fixture = document.getElementById("qunit-fixture");
+
+	var myGreeting = new MyGreeting();
+
+	fixture.appendChild(myGreeting);
+
+	fixture.innerHTML = "<my-plain-greeting></my-plain-greeting>";
+
+	assert.equal(fixture.firstElementChild.innerHTML, "<h1>Hello, unnamed user</h1>");
 
 });
 

--- a/react-to-webcomponent-test.js
+++ b/react-to-webcomponent-test.js
@@ -81,7 +81,7 @@ QUnit.test("works with attributes set with propTypes", function(assert) {
 
 });
 
-QUnit.test("works with no props", function(assert) {
+QUnit.test("works with no propTypes", function(assert) {
 	class Greeting extends React.Component {
 		render() {
 			return <h1>Hello, unnamed user</h1>;

--- a/react-to-webcomponent.js
+++ b/react-to-webcomponent.js
@@ -60,6 +60,9 @@ export default function(ReactComponent, React, ReactDOM) {
 			if(own) {
 				return own;
 			}
+			if (!ReactComponent.propTypes) {
+				return undefined;
+			}
 			if(key in ReactComponent.propTypes) {
 				return { configurable: true, enumerable: true, writable: true, value: undefined };
 			}


### PR DESCRIPTION
Simple change to enable this library to support React components without propTypes. Includes test. Had to fix a small issue with another test as well (needed to reset console.error when test was done).