### PR TITLE
Allow specifying prop types with automatic type casting from attr value string into the underlying React component. Remove propTypes requirement.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # react-to-webcomponent
 
-`react-to-webcomponent` converts [React](https://reactjs.org/) components to [custom elements](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements)! It lets you share React components as native elements that __don't__ require mounted being through React. The custom element acts as a wrapper for the underlying React component. Use these custom elements with any project that uses HTML even in any framework (vue, svelte, angular, ember, canjs) the same way you would use standard HTML elements.
+`react-to-webcomponent` converts [React](https://reactjs.org/) components to [custom elements](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements)! It lets you share React components as native elements that **don't** require mounted being through React. The custom element acts as a wrapper for the underlying React component. Use these custom elements with any project that uses HTML even in any framework (vue, svelte, angular, ember, canjs) the same way you would use standard HTML elements.
 
 `react-to-webcomponent`:
 
@@ -26,10 +26,8 @@ import * as ReactDOM from "react-dom/client"
 // When using React 16 and 17 import ReactDom with the commented statement below instead:
 // import ReactDom from "react-dom"
 
-const Greeting = ({name}) => {
-  return (
-    <h1>Hello, {name}</h1>
-  )
+const Greeting = ({ name }) => {
+  return <h1>Hello, {name}</h1>
 }
 ```
 
@@ -55,7 +53,6 @@ Now we can use `<web-greeting>` like any other HTML element!
 
 Note that by using React 18, `reactToWebComponent` will use the new root API. If your application needs the legacy API, please use React 17
 
-
 In the above case, the web-greeting custom element is not making use of the `name` property from our `Greeting` component.
 
 ## Working with Attributes
@@ -71,13 +68,11 @@ import PropTypes from "prop-types"
 import * as ReactDOM from "react-dom/client"
 
 const Greeting = ({ name }) => {
-  return (
-    <h1>Hello, {name}</h1>
-  )
+  return <h1>Hello, {name}</h1>
 }
 
 Greeting.propTypes = {
-  name: PropTypes.string.isRequired
+  name: PropTypes.string.isRequired,
 }
 ```
 
@@ -92,7 +87,7 @@ as follows:
 </body>
 ```
 
-For projects needing more advanced usage of the web components, see our [prgramatic usage and declarative demos](docs/programatic-usage.md).
+For projects needing more advanced usage of the web components, see our [programatic usage and declarative demos](docs/programatic-usage.md).
 
 We also have a [complete example using a third party library](docs/complete-example.md).
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -8,14 +8,18 @@
   component works with.
 - `ReactDOM` - A version of ReactDOM (or preact-compat) that the component works with.
 - `options` - An optional set of parameters.
+
   - `options.shadow` - Use shadow DOM rather than light DOM.
   - `options.dashStyleAttributes` - convert dashed-attirbutes on the web component into camelCase props for the React component
 
   A new class inheriting from `HTMLElement` is
-returned. This class can be directly passed to `customElements.define` as follows:
+  returned. This class can be directly passed to `customElements.define` as follows:
 
 ```js
-customElements.define("web-greeting", reactToWebComponent(Greeting, React, ReactDOM))
+customElements.define(
+  "web-greeting",
+  reactToWebComponent(Greeting, React, ReactDOM),
+)
 ```
 
 Or the class can be defined and used later:
@@ -32,12 +36,11 @@ document.body.appendChild(myGreeting)
 Or the class can be extended:
 
 ```js
-class WebGreeting extends reactToWebComponent(Greeting, React, ReactDOM)
-{
-	disconnectedCallback(){
-		super.disconnectedCallback()
-		// special stuff
-	}
+class WebGreeting extends reactToWebComponent(Greeting, React, ReactDOM) {
+  disconnectedCallback() {
+    super.disconnectedCallback()
+    // special stuff
+  }
 }
 customElements.define("web-greeting", WebGreeting)
 ```
@@ -45,7 +48,9 @@ customElements.define("web-greeting", WebGreeting)
 Components can also be implemented using [shadow DOM](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM) with either `open` or `closed` mode.
 
 ```js
-const WebGreeting = reactToWebComponent(Greeting, React, ReactDOM, { shadow: 'open' })
+const WebGreeting = reactToWebComponent(Greeting, React, ReactDOM, {
+  shadow: "open",
+})
 
 customElements.define("web-greeting", WebGreeting)
 
@@ -59,20 +64,58 @@ Using dashStyleAttributes to convert dashed-attributes into camelCase React prop
 
 ```js
 class Greeting extends React.Component {
-  render () {
-    return <h1>Hello, { this.props.camelCaseName }</h1>
+  render() {
+    return <h1>Hello, {this.props.camelCaseName}</h1>
   }
 }
 Greeting.propTypes = {
-  camelCaseName: PropTypes.string.isRequired
+  camelCaseName: PropTypes.string.isRequired,
 }
 
 customElements.define(
   "my-dashed-style-greeting",
-  reactToWebComponent(Greeting, React, ReactDOM, { dashStyleAttributes: true })
+  reactToWebComponent(Greeting, React, ReactDOM, { dashStyleAttributes: true }),
 )
 
-document.body.innerHTML = "<my-dashed-style-greeting camel-case-name="Christopher"></my-dashed-style-greetingg>"
+document.body.innerHTML =
+  '<my-dashed-style-greeting camel-case-name="Christopher"></my-dashed-style-greetingg>'
 
 console.log(document.body.firstElementChild.innerHTML) // "<h1>Hello, Christopher</h1>"
+```
+
+Further, attributes on the web component beginning with `on-` or `handle-` will be converted into function references when passed into the underlying React component if the string value is a valid reference to a function on `window` (or on `global`).
+
+```js
+function ThemeSelect({ handleClick }) {
+  return (
+    <div>
+      <button onClick={() => handleClick("V")}>V</button>
+      <button onClick={() => handleClick("Johnny")}>Johnny</button>
+      <button onClick={() => handleClick("Jane")}>Jane</button>
+    </div>
+  )
+}
+
+ThemeSelect.propTypes = {
+  handleClick: PropTypes.func.isRequired,
+}
+
+const WebThemeSelect = reactToWebComponent(ThemeSelect, React, ReactDOM, {
+  dashStyleAttributes: true,
+})
+
+customElements.define("theme-select", WebThemeSelect)
+
+window.globalFn = (selected) => {
+  console.log(selected)
+}
+
+document.body.innerHTML =
+  "<theme-select handle-click='globalFn'></theme-select>"
+
+setTimeout(
+  () => document.querySelector("theme-select button:last-child").click(),
+  0,
+)
+// ^ calls globalFn, logs "Jane"
 ```

--- a/src/react-to-webcomponent.test.jsx
+++ b/src/react-to-webcomponent.test.jsx
@@ -93,7 +93,7 @@ test("works within can-stache and can-stache-bindings (propTypes are writable)",
       expect(myWelcome.childNodes.length).toEqual(1)
       expect(myWelcome.childNodes[0].innerHTML).toEqual("Hello, Bohdi")
       r()
-    }, 100)
+    }, 250)
   })
 })
 
@@ -239,6 +239,104 @@ test("mounts and unmounts underlying react component", async () => {
         body.removeChild(webCom)
         r()
       })
+    }, 0)
+  })
+})
+
+test('Dashed attributes styled set to "true" will also convert the string value of attributes starting with "handle-" into global fn calls', async () => {
+  expect.assertions(1)
+
+  function ThemeSelect({ handleClick }) {
+    return (
+      <div>
+        <button onClick={() => handleClick("V")}>V</button>
+        <button onClick={() => handleClick("Johnny")}>Johnny</button>
+        <button onClick={() => handleClick("Jane")}>Jane</button>
+      </div>
+    )
+  }
+
+  ThemeSelect.propTypes = {
+    handleClick: PropTypes.func.isRequired,
+  }
+
+  const WebThemeSelect = reactToWebComponent(ThemeSelect, React, ReactDOM, {
+    dashStyleAttributes: true,
+  })
+
+  customElements.define("theme-select", WebThemeSelect)
+
+  const body = document.body
+
+  await new Promise((r) => {
+    const failUnlessCleared = setTimeout(() => {
+      delete global.globalFn
+      expect("globalFn was not called to clear the failure timeout").toEqual(
+        "not to fail because globalFn should have been called to clear the failure timeout",
+      )
+      r()
+    }, 1000)
+
+    global.globalFn = (selected) => {
+      delete global.globalFn
+      clearTimeout(failUnlessCleared)
+      expect(selected).toEqual("Jane")
+      r()
+    }
+
+    body.innerHTML = "<theme-select handle-click='globalFn'></theme-select>"
+
+    setTimeout(() => {
+      document.querySelector("theme-select button:last-child").click()
+    }, 0)
+  })
+})
+
+test('Dashed attributes styled set to "true" will also convert the string value of attributes starting with "on-" into global fn calls', async () => {
+  expect.assertions(1)
+
+  function ThemeSelectToo({ onData }) {
+    return (
+      <div>
+        <button onClick={() => onData("V")}>V</button>
+        <button onClick={() => onData("Johnny")}>Johnny</button>
+        <button onClick={() => onData("Jane")}>Jane</button>
+      </div>
+    )
+  }
+
+  ThemeSelectToo.propTypes = {
+    onData: PropTypes.func.isRequired,
+  }
+
+  const WebThemeSelectToo = reactToWebComponent(ThemeSelectToo, React, ReactDOM, {
+    dashStyleAttributes: true,
+  })
+
+  customElements.define("theme-select-too", WebThemeSelectToo)
+
+  const body = document.body
+
+  await new Promise((r) => {
+    const failUnlessCleared = setTimeout(() => {
+      delete global.globalFn
+      expect("globalFn was not called to clear the failure timeout").toEqual(
+        "not to fail because globalFn should have been called to clear the failure timeout",
+      )
+      r()
+    }, 1000)
+
+    global.globalFn = (selected) => {
+      delete global.globalFn
+      clearTimeout(failUnlessCleared)
+      expect(selected).toEqual("Jane")
+      r()
+    }
+
+    body.innerHTML = "<theme-select-too on-data='globalFn'></theme-select>"
+
+    setTimeout(() => {
+      document.querySelector("theme-select-too button:last-child").click()
     }, 0)
   })
 })

--- a/src/react-to-webcomponent.ts
+++ b/src/react-to-webcomponent.ts
@@ -188,6 +188,13 @@ export default function (
       const propertyName = options.dashStyleAttributes
         ? toCamelCaseStyle(name)
         : name
+      if (name.match(/^(?:on|handle)-/)) {
+        if (typeof window !== "undefined") {
+          newValue = window[newValue] || newValue
+        } else if (typeof global !== "undefined") {
+          newValue = global[newValue] || newValue
+        }
+      }
       this[propertyName] = newValue
     }
   }

--- a/src/react-to-webcomponent.ts
+++ b/src/react-to-webcomponent.ts
@@ -3,7 +3,7 @@ const shouldRenderSymbol = Symbol.for("r2wc.shouldRender")
 const rootSymbol = Symbol.for("r2wc.root")
 
 function toDashedStyle(camelCase = "") {
-  return camelCase.replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase()
+  return camelCase.replace(/([a-z0-9])([A-Z])/g, "$1-$2").toLowerCase()
 }
 
 const define = {
@@ -24,6 +24,7 @@ const define = {
 }
 
 interface React {
+  createRef: () => Record<string, unknown>
   createElement: (
     ReactComponent: object,
     data: object,
@@ -193,7 +194,12 @@ export default function (
   ) {
     const propertyName = attrPropMap[name] || name
     switch (propTypes[propertyName]) {
+      case "ref":
       case Function:
+        if (!newValue && propTypes[propertyName] === "ref") {
+          newValue = React.createRef()
+          break
+        }
         if (typeof window !== "undefined") {
           newValue = window[newValue] || newValue
         } else if (typeof global !== "undefined") {


### PR DESCRIPTION
for: (R2WC-19)
for: (R2WC-17)
for: (R2WC-20)
for: #13 

~~Passing the string to new Function would be useless in most cases (since there's no local context) and would be referencing global functions internally to do anything useful...
So I skipped the eval and use the attr value to directly check for a function on `window` (or `global`) (if they exist) and pass that value instead.~~

~~Sucks that it has to be on global buuut it's still very useful if needed on the underlying react component.~~

~~Thoughts?~~

New functionality documented here:
https://github.com/bitovi/react-to-webcomponent/blob/a7bf224cd5406d1cdd50a4397e514c6042173fcc/docs/api.md
